### PR TITLE
Empty script-tag fix

### DIFF
--- a/src/sacy/sacy.php
+++ b/src/sacy/sacy.php
@@ -171,7 +171,7 @@ class WorkUnitExtractor{
 
         if ($this->validTag($attrs)) {
             $path = null;
-            if (!$content){
+            if (!trim($content)){
                 $path = $this->urlToFile($attrs['src']);
                 if ($path === false){
                     return false;


### PR DESCRIPTION
Adds stripping of whitespace before testing content for compilation on script-tags.