### PR TITLE
add support for sassc command (libsass)

### DIFF
--- a/src/sacy/ext-translators.php
+++ b/src/sacy/ext-translators.php
@@ -142,13 +142,22 @@ class ProcessorSass extends ExternalProcessor{
         $path =
             implode(' ', array_map(function($p){ return '-I '.escapeshellarg($p); }, array_unique($libpath)));
 
-        return sprintf('%s --cache-location=%s -s %s %s %s',
-            SACY_TRANSFORMER_SASS,
-            escapeshellarg(sys_get_temp_dir()),
-            $this->getType() == 'text/x-scss' ? '--scss' : '',
-            $plugins,
-            $path
-        );
+        if(basename(SACY_TRANSFORMER_SASS) == "sassc"){
+            return sprintf('%s -s %s %s %s',
+                SACY_TRANSFORMER_SASS,
+                $this->getType() == 'text/x-sass' ? '--sass' : '',
+                $plugins,
+                $path
+            );
+        }else{
+            return sprintf('%s --cache-location=%s -s %s %s %s',
+                SACY_TRANSFORMER_SASS,
+                escapeshellarg(sys_get_temp_dir()),
+                $this->getType() == 'text/x-scss' ? '--scss' : '',
+                $plugins,
+                $path
+            );
+        }
     }
 }
 


### PR DESCRIPTION
I installed `sassc` on my dev env and set the option 'sacy.sass' to `/usr/bin/sassc` to test this.

I don't know whether it makes sense to switch, I'm still testing performance. But It's quite annoying having to wait ~5s for a simple css change to appear when developing locally. Maybe when this is fast enough we could even use something like livereload, but for that to be useful the compilation time of the css has to improve.